### PR TITLE
mod support

### DIFF
--- a/dist/Object Categorization Framework/Base/ABA_KW-OCF_MISC_KID.ini
+++ b/dist/Object Categorization Framework/Base/ABA_KW-OCF_MISC_KID.ini
@@ -531,6 +531,9 @@ Keyword = OCF_MiscHorseGear|Misc Item|CHHornNordic,CHHornImperial
 Keyword = OCF_MiscEmptyVessel_Bottle|Misc Item|CASWaterBOTTLEEmp
 Keyword = _SH_WineBottleKeyword|Misc Item|CASWaterBOTTLEEmp
 
+; Colourful Lutes In Tamriel [ColourfulLutesInTamriel.esp]
+Keyword = OCF_MiscInstrument|Misc Item|LuteBlue,LuteBlank,LuteRed,LuteUnpainted
+
 ; Craftable Training Dummies [Craftable Training Dummies - Dynamic Things Alternative.esp]
 Keyword = OCF_MiscCampingGear|Misc Item|_Novo_Camp_CombatDummy01Misc,_Novo_Camp_BasicTrainingDummy03Misc,_Novo_Camp_ArcheryTargetDummy01Misc,_Gato_Camp_ArmoredTrainingDummy02Misc
 
@@ -878,6 +881,9 @@ Keyword = OCF_VesselBottlePotion|Misc Item|XJKwpPotionBottle,XJKwpPotionBottle01
 
 ; JS Instruments [JS Instruments of Skyrim SE - Uniques.esp]
 Keyword = OCF_MiscInstrument|Misc Item|JS_FinnsLute,JS_PanteaFlute,JS_RjornsDrum
+
+; JS Instruments of Skyrim SE - Separated Recolors [(f)luterecolors.esp]
+Keyword = OCF_MiscInstrument|Misc Item|GrassyLute,ShadowLute,DrunkenLute,TearfulLute,IvoryFlute
 
 ; Keep it Clean [Keep It Clean.esp]
 Keyword = OCF_BookTextRecipe_Crafting|Misc Item|SB_CShacks_BathKit00,SB_CShacks_BathKit01,SB_CShacks_BathKit02,SB_CShacks_BathKit03,SB_CShacks_BathKit04


### PR DESCRIPTION
Added support for Colourful Lutes In Tamriel (clit) and JS Instruments of Skyrim SE - Separated Recolors

The changelog was sort of confusing so here:
[Colourful Lutes In Tamriel](https://www.nexusmods.com/skyrimspecialedition/mods/92543) (`MISC`)
[JS Instruments of Skyrim SE - Separated Recolors](https://www.nexusmods.com/skyrimspecialedition/mods/126181) (`MISC`)